### PR TITLE
Dockerize existing sample project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,34 @@
+#
+# This file can be used to create a docker container that will automatically execute
+# the InpaintHTTP executeable on running it.
+#
+# To build this file you need to run docker under Windows in Windows container mode.
+#
+# Building: docker build -t <your tag> Dockerfile
+# Example:  docker build -t inpainter/inpainter Dockerfile
+#
+# Running: docker run -p 8069:8069 <your tag>
+# Example: docker run -p 8069:8069 inpainter/inpainter
+#
+
+# create a build container with .NET v4.7.2
 FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-20190312-windowsservercore-ltsc2019 AS build
 WORKDIR /app
 
-# copy csproj and restore as distinct layers
+# copy the project directory to the build container and build the whole solution
 COPY . .
 RUN nuget restore Inpainting.sln
 RUN msbuild Inpainting.sln /p:Configuration=Release
 
-
+# finally create the runtime container
 FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-20190312-windowsservercore-ltsc2019 AS runtime
+
+# expose port 8069 of the webserver
 EXPOSE 8069
+
+# copy the compiled release version of the InpaintHTTP sample to the app directory...
 WORKDIR /app
 COPY --from=build /app/Samples/InpaintHTTP/bin/Release/ ./
+
+# ...and set the entry point of the sample
 ENTRYPOINT ["InpaintHTTP.exe"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-20190312-windowsservercore-ltsc2019 AS build
+WORKDIR /app
+
+# copy csproj and restore as distinct layers
+COPY . .
+RUN nuget restore Inpainting.sln
+RUN msbuild Inpainting.sln /p:Configuration=Release
+
+
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-20190312-windowsservercore-ltsc2019 AS runtime
+EXPOSE 8069
+WORKDIR /app
+COPY --from=build /app/Samples/InpaintHTTP/bin/Release/ ./
+ENTRYPOINT ["InpaintHTTP.exe"]

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,26 +1,27 @@
 #
 # This file can be used to create a docker container that will automatically execute
-# the InpaintHTTP executeable on running it. This container is based on the Mono build
-# system and should run under Windows and Linux.
+# the InpaintHTTP executeable on running it.
 #
-# Building: docker build -t <your tag> Dockerfile
-# Example:  docker build -t inpainter/inpainter Dockerfile
+# To build this file you need to run docker under Windows in Windows container mode.
+#
+# Building: docker build -t <your tag> Dockerfile.Windows
+# Example:  docker build -t inpainter/inpainter Dockerfile.Windows
 #
 # Running: docker run -p 8069:8069 <your tag>
 # Example: docker run -p 8069:8069 inpainter/inpainter
 #
 
-# create a build container with the latest Mono version
-FROM mono AS build
+# create a build container with .NET v4.7.2
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-20190312-windowsservercore-ltsc2019 AS build
 WORKDIR /app
 
 # copy the project directory to the build container and build the whole solution
 COPY . .
 RUN nuget restore Inpainting.sln
-RUN xbuild Inpainting.sln /p:Configuration=Release
+RUN msbuild Inpainting.sln /p:Configuration=Release
 
 # finally create the runtime container
-FROM mono AS runtime
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-20190312-windowsservercore-ltsc2019 AS runtime
 
 # expose port 8069 of the webserver
 EXPOSE 8069
@@ -30,4 +31,4 @@ WORKDIR /app
 COPY --from=build /app/Samples/InpaintHTTP/bin/Release/ ./
 
 # ...and set the entry point of the sample
-CMD [ "mono",  "./InpaintHTTP.exe" ]
+ENTRYPOINT ["InpaintHTTP.exe"]

--- a/Inpainting.sln
+++ b/Inpainting.sln
@@ -18,6 +18,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8346CA1E-6B09-481C-A54D-BF12073E9375}"
 	ProjectSection(SolutionItems) = preProject
 		Dockerfile = Dockerfile
+		Dockerfile.Windows = Dockerfile.Windows
 	EndProjectSection
 EndProject
 Global

--- a/Inpainting.sln
+++ b/Inpainting.sln
@@ -15,6 +15,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InpaintWinForms", "Samples\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InpaintHTTP", "Samples\InpaintHTTP\InpaintHTTP.csproj", "{B753EE46-D174-4385-AF6D-5FC362C00749}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8346CA1E-6B09-481C-A54D-BF12073E9375}"
+	ProjectSection(SolutionItems) = preProject
+		Dockerfile = Dockerfile
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,7 +33,6 @@ Global
 		{7A507467-F683-44BD-A27C-615ED8BE18FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7A507467-F683-44BD-A27C-615ED8BE18FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A507467-F683-44BD-A27C-615ED8BE18FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7A507467-F683-44BD-A27C-615ED8BE18FF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F541908F-ADAD-4EEB-B0BD-3A56F51930FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F541908F-ADAD-4EEB-B0BD-3A56F51930FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F541908F-ADAD-4EEB-B0BD-3A56F51930FB}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
I created a Dockerfile that is containing a multi stage build in a Windows container. The documentation for it is contained in the Dockerfile, however, to build it, just use

> docker build -t inpainter/inpainter Dockerfile

and run it with

> docker run -p 8069:8069 inpainter/inpainter

afterwards. The container should be started and you can access the webserver via "http://localhost:8069".